### PR TITLE
Update RCTBluetoothSerialPackage.java

### DIFF
--- a/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialPackage.java
+++ b/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialPackage.java
@@ -13,19 +13,16 @@ import com.facebook.react.bridge.JavaScriptModule;
 public class RCTBluetoothSerialPackage implements ReactPackage {
     static final String TAG = "BluetoothSerial";
 
-    @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new RCTBluetoothSerialModule(reactContext));
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
 
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Just removed all "@overrides", becouse this was breaking the React Native application. The application acused that the @override was deprecated